### PR TITLE
add eval function and example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,15 +19,14 @@ pub fn build(b: *std.Build) !void {
 
     const tests = b.addTest(.{
         .name = "js-test",
-        .kind = .test_exe,
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
     });
-    tests.install();
+    b.installArtifact(tests);
 
     const test_step = b.step("test", "Run tests");
-    const tests_run = tests.run();
+    const tests_run = b.addRunArtifact(tests);
     test_step.dependOn(&tests_run.step);
 
     // Example
@@ -38,7 +37,8 @@ pub fn build(b: *std.Build) !void {
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize,
         });
-        wasm.setOutputDir("example");
+        wasm.emit_directory = @constCast(&.{ .step = &wasm.step });
+        wasm.rdynamic = true;
         wasm.addModule("zig-js", module(b));
 
         const step = b.step("example", "Build the example project (Zig only)");

--- a/build.zig
+++ b/build.zig
@@ -37,11 +37,12 @@ pub fn build(b: *std.Build) !void {
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize,
         });
-        wasm.emit_directory = @constCast(&.{ .step = &wasm.step });
         wasm.rdynamic = true;
         wasm.addModule("zig-js", module(b));
 
         const step = b.step("example", "Build the example project (Zig only)");
-        step.dependOn(&wasm.step);
+        step.dependOn(&b.addInstallArtifact(wasm, .{
+            .dest_dir = .{.override=.{.custom="../example"}},
+        }).step);
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -1,18 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub fn module(b: *std.Build) *std.build.Module {
-    return b.createModule(.{
-        .source_file = .{ .path = (comptime thisDir()) ++ "/src/main.zig" },
-    });
-}
-
-fn thisDir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
-}
-
-pub const Options = struct {};
-
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -29,6 +17,9 @@ pub fn build(b: *std.Build) !void {
     const tests_run = b.addRunArtifact(tests);
     test_step.dependOn(&tests_run.step);
 
+    const zigjs = b.addModule("zig-js", .{
+        .source_file = .{ .path = "src/main.zig" },
+    });
     // Example
     {
         const wasm = b.addSharedLibrary(.{
@@ -38,7 +29,7 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         wasm.rdynamic = true;
-        wasm.addModule("zig-js", module(b));
+        wasm.addModule("zig-js", zigjs);
 
         const step = b.step("example", "Build the example project (Zig only)");
         step.dependOn(&b.addInstallArtifact(wasm, .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,6 @@
+.{
+    .name = "zig-js",
+    .version = "0.0.1",
+    .dependencies = .{
+    },
+}

--- a/example/app.ts
+++ b/example/app.ts
@@ -17,10 +17,11 @@ fetch(url.href).then(response =>
 ).then(bytes =>
   WebAssembly.instantiate(bytes, importObject)
 ).then(results => {
-  const { memory, alert, set_title } = results.instance.exports;
+  const { memory, alert, set_title, zig_eval } = results.instance.exports;
   zjs.memory = memory;
 
   // Call whatever example you want:
   set_title();
+  zig_eval();
   //alert();
 });

--- a/example/app.ts
+++ b/example/app.ts
@@ -17,8 +17,10 @@ fetch(url.href).then(response =>
 ).then(bytes =>
   WebAssembly.instantiate(bytes, importObject)
 ).then(results => {
-  const { memory, alert, set_title, zig_eval } = results.instance.exports;
-  zjs.memory = memory;
+  zjs.getExports(results.instance.exports);
+  console.log(JSON.stringify(results.instance.exports));
+
+  const { set_title, zig_eval } = results.instance.exports;
 
   // Call whatever example you want:
   set_title();

--- a/example/example.payload.js
+++ b/example/example.payload.js
@@ -1,0 +1,18 @@
+try {
+    console.log(this);
+    
+    const example = {
+        description: "This message is passed from a zig @embed()'ed js string in wasm.",
+        msg: "Hello World from zig-js",
+    };
+    console.log(example);
+    
+    const div = document.createElement('pre');
+    div.style.backgroundColor = "lightgray";
+    div.innerText = JSON.stringify(example, null, 4);
+    this.body.appendChild(div);
+} catch (error) {
+    console.error(error);
+}
+// the last statement needs to be a returnable value
+null;

--- a/example/example.payload.js
+++ b/example/example.payload.js
@@ -10,7 +10,7 @@ try {
     const div = document.createElement('pre');
     div.style.backgroundColor = "lightgray";
     div.innerText = JSON.stringify(example, null, 4);
-    this.body.appendChild(div);
+    document.body.appendChild(div);
 } catch (error) {
     console.error(error);
 }

--- a/example/main.zig
+++ b/example/main.zig
@@ -15,6 +15,18 @@ fn set_title_() !void {
     try doc.set("title", js.string("Hello!"));
 }
 
+export fn zig_eval() void {
+    __zig_eval() catch unreachable;
+}
+
+fn __zig_eval() !void {
+    const script = js.string(@embedFile("example.payload.js"));
+
+    const doc = try js.global.get(js.Object, "document");
+
+    _ = try doc.eval(void, script);
+}
+
 fn alert_() !void {
     try js.global.call(void, "alert", .{js.string("Hello, world!")});
 }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../js": {
       "name": "zig-js-glue",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@parcel/packager-ts": "^2.8.0",

--- a/js/src/zigjs.ts
+++ b/js/src/zigjs.ts
@@ -63,6 +63,7 @@ export class ZigJS {
         valueStringCopy: this.valueStringCopy.bind(this),
         valueNew: this.valueNew.bind(this),
         funcApply: this.funcApply.bind(this),
+        funcEval: this.funcEval.bind(this),
       },
     };
   }
@@ -162,6 +163,20 @@ export class ZigJS {
 
     const result = Reflect.apply(fn, thisVal, args);
     this.storeValue(out, result);
+  }
+
+  /**
+   * Eval a js string by id with 'this' set to current Object. Return the last statement.
+   * */
+  protected funcEval(__out: number, __thisRef: number, __script_addr: number, __script_len: number): void {
+    const __thisVal = this.loadRef(__thisRef);
+    const __script = this.loadString(__script_addr, __script_len);
+    function __f (){
+      return eval(__script);
+    }
+  
+    const __result = __f.call(__thisVal);
+    this.storeValue(__out, __result);
   }
 
   /**
@@ -282,5 +297,6 @@ export interface ImportObject {
     valueDeinit: (id: number) => void;
     valueNew: (out: number, funcId: number, argsPtr: number, argsLen: number) => void;
     funcApply: (out: number, funcId: number, thisRef: number, argsPtr: number, argsLen: number) => void;
+    funcEval: (__out: number, __thisRef: number, __script_addr: number, __script_len: number) => void;
   };
 };

--- a/js/src/zigjs.ts
+++ b/js/src/zigjs.ts
@@ -67,6 +67,10 @@ export class ZigJS {
       },
     };
   }
+  
+  getExports(exports): void {
+    this.memory = exports.memory;
+  }
 
   /**
    * Get a value from the JS environment.

--- a/src/extern.zig
+++ b/src/extern.zig
@@ -21,6 +21,7 @@ pub usingnamespace if (!builtin.is_test) struct {
         argsPtr: [*]const u64,
         argsLen: usize,
     ) void;
+    pub extern "zig-js" fn funcEval(out: *u64, this: *u64, scriptPtr: u32, scriptLen: u32) void;
 } else struct {
     const alloc = std.testing.allocator;
 

--- a/src/extern.zig
+++ b/src/extern.zig
@@ -64,7 +64,7 @@ pub usingnamespace if (!builtin.is_test) struct {
     pub fn valueGet(out: *u64, id: u32, addr: [*]const u8, len: usize) void {
         const obj = &values.items[id].object;
         const key = addr[0..len];
-        out.* = obj.get(key) orelse @bitCast(u64, js.Ref.null);
+        out.* = obj.get(key) orelse @as(u64, @bitCast(js.Ref.null));
     }
 
     pub fn valueSet(id: u32, addr: [*]const u8, len: usize, ref_ptr: *const u64) void {
@@ -75,8 +75,8 @@ pub usingnamespace if (!builtin.is_test) struct {
 
     pub fn valueObjectCreate(out: *u64) void {
         values.append(alloc, .{ .object = .{} }) catch unreachable;
-        const ref: js.Ref = .{ .type_id = .object, .id = @intCast(u32, values.items.len - 1) };
-        out.* = @bitCast(u64, ref);
+        const ref: js.Ref = .{ .type_id = .object, .id = @as(u32, @intCast(values.items.len - 1)) };
+        out.* = @as(u64, @bitCast(ref));
     }
 
     pub fn valueStringCreate(out: *u64, addr: [*]const u8, len: usize) void {
@@ -87,12 +87,12 @@ pub usingnamespace if (!builtin.is_test) struct {
         values.append(alloc, .{ .string = copy }) catch unreachable;
 
         // Create the ref
-        const ref: js.Ref = .{ .type_id = .string, .id = @intCast(u32, values.items.len - 1) };
-        out.* = @bitCast(u64, ref);
+        const ref: js.Ref = .{ .type_id = .string, .id = @as(u32, @intCast(values.items.len - 1)) };
+        out.* = @as(u64, @bitCast(ref));
     }
 
     pub fn valueStringLen(id: u32) u32 {
-        return @intCast(u32, values.items[id].string.len);
+        return @as(u32, @intCast(values.items[id].string.len));
     }
 
     pub fn valueStringCopy(id: u32, addr: [*]u8, max: usize) void {

--- a/src/object.zig
+++ b/src/object.zig
@@ -63,12 +63,11 @@ pub const Object = struct {
         script: js.String,
     ) !Get(T).result {
         var result: u64 = undefined;
-        var ref = @bitCast(u64, @enumToInt(self.value));
-        @import("extern.zig").funcEval( &result, &ref, @as(u32, @ptrToInt(script.ptr)), @as(u32, script.len));
-        const rv = @intToEnum(js.Value, result);
+        var ref = @as(u64, @bitCast(@intFromEnum(self.value)));
+        @import("extern.zig").funcEval(&result, &ref, @as(u32, @intFromPtr(script.ptr)), @as(u32, script.len));
+        const rv = @as(js.Value, @enumFromInt(result));
         return try convertValue(T, undefined, rv);
     }
-
 
     /// Call a function on a object. This will set the "this" parameter
     /// to the object properly. This should only be used with return types
@@ -172,11 +171,11 @@ pub const Object = struct {
 
             bool => return try v.boolean(),
             []u8 => return try v.string(alloc),
-            f16, f32, f64 => return @floatCast(info.result_unwrapped, try v.float()),
+            f16, f32, f64 => return @as(info.result_unwrapped, @floatCast(try v.float())),
 
-            else => if (t_info == .Int) return @floatToInt(
+            else => if (t_info == .Int) return @as(
                 info.result_unwrapped,
-                try v.float(),
+                @intFromFloat(try v.float()),
             ),
         }
 

--- a/src/object.zig
+++ b/src/object.zig
@@ -56,6 +56,20 @@ pub const Object = struct {
         try self.value.set(n, js_value);
     }
 
+    /// Evaluate a previously created String as a js script
+    pub fn eval(
+        self: Object,
+        comptime T: type,
+        script: js.String,
+    ) !Get(T).result {
+        var result: u64 = undefined;
+        var ref = @bitCast(u64, @enumToInt(self.value));
+        @import("extern.zig").funcEval( &result, &ref, @as(u32, @ptrToInt(script.ptr)), @as(u32, script.len));
+        const rv = @intToEnum(js.Value, result);
+        return try convertValue(T, undefined, rv);
+    }
+
+
     /// Call a function on a object. This will set the "this" parameter
     /// to the object properly. This should only be used with return types
     /// that don't need any allocations.

--- a/src/ref.zig
+++ b/src/ref.zig
@@ -83,7 +83,7 @@ pub const Ref = packed struct(u64) {
 
     pub fn toF64(self: Ref) f64 {
         assert(self.typeOf() == .number);
-        return @as(f64, @bitCast(self));
+        return @bitCast(self);
     }
 
     // This just helps test what JS will do

--- a/src/ref.zig
+++ b/src/ref.zig
@@ -83,7 +83,7 @@ pub const Ref = packed struct(u64) {
 
     pub fn toF64(self: Ref) f64 {
         assert(self.typeOf() == .number);
-        return @bitCast(f64, self);
+        return @as(f64, @bitCast(self));
     }
 
     // This just helps test what JS will do
@@ -91,8 +91,8 @@ pub const Ref = packed struct(u64) {
         const testing = std.testing;
 
         {
-            const n: u64 = (@intCast(u64, @intCast(u32, nanHead) << 3 | 2) << 32) | 14;
-            const ref = @bitCast(Ref, n);
+            const n: u64 = (@as(u64, @intCast(@as(u32, @intCast(nanHead)) << 3 | 2)) << 32) | 14;
+            const ref = @as(Ref, @bitCast(n));
             try testing.expectEqual(nanHead, ref.head);
             try testing.expectEqual(js.Type.string, ref.typeOf());
             try testing.expectEqual(@as(u32, 14), ref.id);
@@ -112,14 +112,14 @@ pub const Ref = packed struct(u64) {
         const testing = std.testing;
 
         {
-            const ref = @bitCast(Ref, @bitCast(u64, @as(f64, 1.234)));
+            const ref = @as(Ref, @bitCast(@as(u64, @bitCast(@as(f64, 1.234)))));
             try testing.expectEqual(js.Type.number, ref.typeOf());
             try testing.expectEqual(@as(f64, 1.234), ref.toF64());
         }
 
         // zero
         {
-            const ref = @bitCast(Ref, @bitCast(u64, @as(f64, 0)));
+            const ref = @as(Ref, @bitCast(@as(u64, @bitCast(@as(f64, 0)))));
             try testing.expectEqual(js.Type.number, ref.typeOf());
             try testing.expectEqual(@as(f64, 0), ref.toF64());
         }
@@ -130,14 +130,14 @@ pub const Ref = packed struct(u64) {
 
         // Stdlib nan
         {
-            const ref = @bitCast(Ref, @bitCast(u64, std.math.nan_f64));
+            const ref = @as(Ref, @bitCast(@as(u64, @bitCast(std.math.nan_f64))));
             try testing.expectEqual(js.Type.number, ref.typeOf());
             try testing.expect(std.math.isNan(ref.toF64()));
         }
 
         // Manual nan
         {
-            const ref = @bitCast(Ref, @as(u64, 0x7FF8_0000_0000_0000));
+            const ref = @as(Ref, @bitCast(@as(u64, 0x7FF8_0000_0000_0000)));
             try testing.expectEqual(js.Type.number, ref.typeOf());
         }
     }

--- a/src/value.zig
+++ b/src/value.zig
@@ -43,7 +43,7 @@ pub const String = struct {
         const testing = std.testing;
         const raw = "hello!";
         const v = init(raw);
-        try testing.expectEqual(@ptrCast([*]const u8, raw), v.ptr);
+        try testing.expectEqual(@as([*]const u8, @ptrCast(raw)), v.ptr);
         try testing.expectEqual(raw.len, v.len);
     }
 
@@ -51,7 +51,7 @@ pub const String = struct {
         const testing = std.testing;
         const raw = @as([]const u8, "hello!");
         const v = init(raw);
-        try testing.expectEqual(@ptrCast([*]const u8, raw), v.ptr);
+        try testing.expectEqual(@as([*]const u8, @ptrCast(raw)), v.ptr);
         try testing.expectEqual(raw.len, v.len);
     }
 };
@@ -67,13 +67,13 @@ pub const Value = enum(u64) {
     // "runtime". The "runtime" value gives access to the "this" value
     // for the ZigJS JS class. This makes it possible to access the memory
     // for example.
-    nan = @bitCast(u64, js.Ref.nan),
-    null = @bitCast(u64, js.Ref.null),
-    true = @bitCast(u64, js.Ref.true),
-    false = @bitCast(u64, js.Ref.false),
-    undefined = @bitCast(u64, js.Ref.undefined),
-    global = @bitCast(u64, js.Ref.global),
-    runtime = @bitCast(u64, js.Ref.runtime),
+    nan = @as(u64, @bitCast(js.Ref.nan)),
+    null = @as(u64, @bitCast(js.Ref.null)),
+    true = @as(u64, @bitCast(js.Ref.true)),
+    false = @as(u64, @bitCast(js.Ref.false)),
+    undefined = @as(u64, @bitCast(js.Ref.undefined)),
+    global = @as(u64, @bitCast(js.Ref.global)),
+    runtime = @as(u64, @bitCast(js.Ref.runtime)),
 
     _,
 
@@ -89,20 +89,20 @@ pub const Value = enum(u64) {
         return switch (@typeInfo(@TypeOf(x))) {
             .Null => .null,
             .Bool => if (x) .true else .false,
-            .ComptimeInt => init(@intToFloat(f64, x)),
-            .ComptimeFloat => init(@floatCast(f64, x)),
+            .ComptimeInt => init(@as(f64, @floatFromInt(x))),
+            .ComptimeFloat => init(@as(f64, @floatCast(x))),
             .Float => |t| float: {
                 if (t.bits > 64) @compileError("Value only supports floats up to 64 bits");
                 if (std.math.isNan(x)) break :float .nan;
-                break :float @intToEnum(Value, @bitCast(u64, @floatCast(f64, x)));
+                break :float @as(Value, @enumFromInt(@as(u64, @bitCast(@as(f64, @floatCast(x))))));
             },
 
             // All numbers in JS are 64-bit floats, so we try the conversion
             // here and accept a runtime/compile-time error if x is invalid.
-            .Int => init(@intToFloat(f64, x)),
+            .Int => init(@as(f64, @floatFromInt(x))),
 
             .Pointer => |p| switch (p.size) {
-                .One, .Many => init(@ptrToInt(x)),
+                .One, .Many => init(@intFromPtr(x)),
                 else => unreachable,
             },
 
@@ -112,12 +112,12 @@ pub const Value = enum(u64) {
                 js.Object => blk: {
                     var result: u64 = undefined;
                     ext.valueObjectCreate(&result);
-                    break :blk @intToEnum(Value, result);
+                    break :blk @as(Value, @enumFromInt(result));
                 },
                 String => blk: {
                     var result: u64 = undefined;
                     ext.valueStringCreate(&result, x.ptr, x.len);
-                    break :blk @intToEnum(Value, result);
+                    break :blk @as(Value, @enumFromInt(result));
                 },
                 else => unreachable,
             },
@@ -136,13 +136,13 @@ pub const Value = enum(u64) {
         if (self.typeOf() != .object) return js.Error.InvalidType;
         var result: u64 = undefined;
         ext.valueGet(&result, self.ref().id, n.ptr, n.len);
-        return @intToEnum(Value, result);
+        return @as(Value, @enumFromInt(result));
     }
 
     /// Set the value of a property on an object.
     pub fn set(self: Value, n: []const u8, v: Value) !void {
         if (self.typeOf() != .object) return js.Error.InvalidType;
-        ext.valueSet(self.ref().id, n.ptr, n.len, &@bitCast(u64, v.ref()));
+        ext.valueSet(self.ref().id, n.ptr, n.len, &@as(u64, @bitCast(v.ref())));
     }
 
     /// Call this value as a function.
@@ -152,11 +152,11 @@ pub const Value = enum(u64) {
         ext.funcApply(
             &result,
             self.ref().id,
-            &@bitCast(u64, this.ref()),
-            @ptrCast([*]const u64, args.ptr),
+            &@as(u64, @bitCast(this.ref())),
+            @as([*]const u64, @ptrCast(args.ptr)),
             args.len,
         );
-        return @intToEnum(Value, result);
+        return @as(Value, @enumFromInt(result));
     }
 
     /// Call "new" on this value like a constructor.
@@ -166,10 +166,10 @@ pub const Value = enum(u64) {
         ext.valueNew(
             &result,
             self.ref().id,
-            @ptrCast([*]const u64, args.ptr),
+            @as([*]const u64, @ptrCast(args.ptr)),
             args.len,
         );
-        return @intToEnum(Value, result);
+        return @as(Value, @enumFromInt(result));
     }
 
     /// Returns the bool value if this is a boolean.
@@ -181,7 +181,7 @@ pub const Value = enum(u64) {
     /// Returns the float value if this is a number.
     pub fn float(self: Value) !f64 {
         if (self.typeOf() != .number) return js.Error.InvalidType;
-        return @bitCast(f64, @enumToInt(self));
+        return @as(f64, @bitCast(@intFromEnum(self)));
     }
 
     /// Returns the UTF-8 encoded string value. The resulting value must be
@@ -191,7 +191,7 @@ pub const Value = enum(u64) {
 
         // Get the length and allocate our pointer
         const len = ext.valueStringLen(self.ref().id);
-        var buf = try alloc.alloc(u8, @intCast(usize, len));
+        var buf = try alloc.alloc(u8, @as(usize, @intCast(len)));
         errdefer alloc.free(buf);
 
         // Copy the string into the buffer
@@ -206,7 +206,7 @@ pub const Value = enum(u64) {
     }
 
     inline fn ref(self: Value) js.Ref {
-        return @bitCast(js.Ref, @enumToInt(self));
+        return @as(js.Ref, @bitCast(@intFromEnum(self)));
     }
 };
 
@@ -267,7 +267,7 @@ test "Value.init: strings" {
 
     {
         const str = "hello!";
-        const v = Value.init(String{ .ptr = @ptrCast([*]const u8, str), .len = str.len });
+        const v = Value.init(String{ .ptr = @as([*]const u8, @ptrCast(str)), .len = str.len });
         defer v.deinit();
         try testing.expectEqual(js.Type.string, v.typeOf());
 


### PR DESCRIPTION
Hi, interesting peace of software,

one way to tackle lots of back&forth -es between wasm and js would be to pass bigger scripts from @embed to js,
then eval() them.

As for security concerns i dont think it's worse then calling any global, as long as the script is not templated.
It may be a performance/debuggability hit though.

It would be interesting to have the scripts transpiled/minified from typescript when running `zig build`.
Same goes for the Host JS module itself.

I was able to run the example with "[bun](https://github.com/oven-sh/bun) run start" instead of npm, 
It would be awesome to have something like this integrated, but i dont think they have a proper API (yet).
