### PR TITLE
Update code to latest zig version

### DIFF
--- a/src/extern.zig
+++ b/src/extern.zig
@@ -95,7 +95,7 @@ pub usingnamespace if (!builtin.is_test) struct {
     }
 
     pub fn valueStringCopy(id: u32, addr: [*]u8, max: usize) void {
-        std.mem.copy(u8, addr[0..max], values.items[id].string);
+        @memcpy(addr[0..max], values.items[id].string);
     }
 
     pub fn valueDeinit(id: u32) void {

--- a/src/ref.zig
+++ b/src/ref.zig
@@ -130,7 +130,7 @@ pub const Ref = packed struct(u64) {
 
         // Stdlib nan
         {
-            const ref = @as(Ref, @bitCast(@as(u64, @bitCast(std.math.nan_f64))));
+            const ref = @as(Ref, @bitCast(@as(u64, @bitCast(std.math.nan(f64)))));
             try testing.expectEqual(js.Type.number, ref.typeOf());
             try testing.expect(std.math.isNan(ref.toF64()));
         }

--- a/src/value.zig
+++ b/src/value.zig
@@ -191,7 +191,7 @@ pub const Value = enum(u64) {
 
         // Get the length and allocate our pointer
         const len = ext.valueStringLen(self.ref().id);
-        var buf = try alloc.alloc(u8, @intCast(len));
+        const buf = try alloc.alloc(u8, @intCast(len));
         errdefer alloc.free(buf);
 
         // Copy the string into the buffer
@@ -239,9 +239,9 @@ test "Value.init: bools" {
 
 test "Value.init: floats" {
     const testing = std.testing;
-    try testing.expectEqual(Value.nan, Value.init(std.math.nan_f16));
-    try testing.expectEqual(Value.nan, Value.init(std.math.nan_f32));
-    try testing.expectEqual(Value.nan, Value.init(std.math.nan_f64));
+    try testing.expectEqual(Value.nan, Value.init(std.math.nan(f16)));
+    try testing.expectEqual(Value.nan, Value.init(std.math.nan(f32)));
+    try testing.expectEqual(Value.nan, Value.init(std.math.nan(f64)));
 
     {
         const v = Value.init(1.234);


### PR DESCRIPTION
  - use @memcpy instead of std.mem.copy
  - use math.nan(T) instead of math.nan_T
  - use const when a variable is never mutated