### PR TITLE
Fix return bool

### DIFF
--- a/js/src/zigjs.ts
+++ b/js/src/zigjs.ts
@@ -205,17 +205,21 @@ export class ZigJS {
     if (this.memory == null) return;
     const view = new DataView(this.memory.buffer);
 
-    if (typeof val === "number") {
-      // We have to turn NaNs into a single value (since NaN can be
-      // represented by multiple encodings).
-      if (isNaN(val)) {
-        view.setUint32(out, predefined.nan, true);
+    switch (typeof val) {
+      case "number":
+        // We have to turn NaNs into a single value (since NaN can be
+        // represented by multiple encodings).
+        if (isNaN(val)) {
+          view.setUint32(out, predefined.nan, true);
+          view.setUint32(out + 4, NAN_PREFIX, true);
+        } else {
+          view.setFloat64(out, val, true);
+        }
+        return;
+      case "boolean":
+        view.setUint32(out, val ? predefined.true : predefined.false, true);
         view.setUint32(out + 4, NAN_PREFIX, true);
-      } else {
-        view.setFloat64(out, val, true);
-      }
-
-      return;
+        return;
     }
 
     if (val === null) {

--- a/src/value.zig
+++ b/src/value.zig
@@ -173,7 +173,7 @@ pub const Value = enum(u64) {
     }
 
     /// Returns the bool value if this is a boolean.
-    pub fn boolean(self: Value) !f64 {
+    pub fn boolean(self: Value) !bool {
         if (self.typeOf() != .boolean) return js.Error.InvalidType;
         return self == .true;
     }


### PR DESCRIPTION
I found that if I specify a return value of type `bool` for `Object.get` or `Object.call`, it does not compile and does not work. I think both Zig and JavaScript need to be modified. 

* In the Zig code, change the return type of `Value.boolean` from `!f64` to `!bool` because it is probably incorrect.

* In the JavaScript code, when the obtained value is a boolean, write to the output pointer is probably missing, so add it.
