### PR TITLE
fix: add rdynamic to fix missing WASM exports

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,7 @@ pub fn build(b: *std.Build) !void {
         wasm.root_module.addImport("zig-js", zig_js_module);
         wasm.entry = .disabled;
         wasm.export_memory = true;
+        wasm.rdynamic = true;
 
         // custom's path is relative to zig-out
         const wasm_install = b.addInstallFileWithDir(


### PR DESCRIPTION
fixes #8 

I'm not sure how this was working before but it appears this is needed to prevent zig from stripping the WASM exports.

Related PR for Zig:  https://github.com/ziglang/zig/pull/14102